### PR TITLE
Remove private data objects references

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ for information on how to contribute and the guidelines for contributions.
 Hyperledger Trusted Compute Framework is released under the Apache License
 Version 2.0 software license. See the [license file](LICENSE) for more details.
 
-Hyperledger Private Data Objects documentation is licensed under the Creative
-Commons Attribution 4.0 International License. You may obtain a copy of the
-license at: http://creativecommons.org/licenses/by/4.0/.
+Hyperledger Trusted Compute Framework documentation is licensed under the
+Creative Commons Attribution 4.0 International License. You may obtain a copy
+of the license at: http://creativecommons.org/licenses/by/4.0/.
 
 © Copyright 2019, Intel Corporation.

--- a/tcs/core/common/python/setup.py
+++ b/tcs/core/common/python/setup.py
@@ -171,7 +171,7 @@ version = subprocess.check_output(
 
 setup(name='tcf_crypto_library',
       version=version,
-      description='Common library for private objects',
+      description='Common library for Trusted Compute Framework',
       author='Intel Labs',
       packages=find_packages(),
       install_requires=[],


### PR DESCRIPTION
References to PDO is removed in README and setup.py files.

Signed-off-by: acmanjun <manjunath.a.c@intel.com>
Signed-off-by: danintel <daniel.anderson@intel.com>