### PR TITLE
Move workload related classes from dispatcher to respective workloads

### DIFF
--- a/common/sgx_workload/workload_processor.h
+++ b/common/sgx_workload/workload_processor.h
@@ -29,9 +29,6 @@ struct WorkOrderDispatchTableEntry {
 };
 
 class WorkloadProcessor : public tc::WorkOrderProcessorInterface {
-private:
-    // Convention: we use the key "IntrinsicState" key to store the value
-    const std::string intrinsic_state_key_ = "IntrinsicState";
 public:
     WorkloadProcessor(void);
     virtual ~WorkloadProcessor(void);

--- a/examples/apps/CMakeLists.txt
+++ b/examples/apps/CMakeLists.txt
@@ -15,6 +15,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
 
 INCLUDE(CMakeVariables.txt)
+SET(GENERIC_PRIVATE_INCLUDE_DIRS "." "${TCF_TOP_DIR}/tc/sgx/common"
+	"${TCF_TOP_DIR}/tc/sgx/common/work_order_interface")
 
 ################################################################################
 ADD_SUBDIRECTORY(echo/workload)

--- a/examples/apps/echo/workload/echo.cpp
+++ b/examples/apps/echo/workload/echo.cpp
@@ -15,6 +15,43 @@
 
 #include "echo.h"
 
-std::string EchoResultImpl::Process(std::string str_in) {
+EchoResult::EchoResult() {}
+
+EchoResult::~EchoResult() {}
+
+std::string EchoResult::Process(std::string str_in) {
         return "RESULT: " + str_in;
 }
+
+void EchoResult::ProcessWorkOrder(
+        std::string workload_id,
+        const ByteArray& participant_address,
+        const ByteArray& enclave_id,
+        const ByteArray& work_order_id,
+        const std::vector<tcf::WorkOrderData>& in_work_order_data,
+        std::vector<tcf::WorkOrderData>& out_work_order_data) {
+    std::string result_str;
+    int i = 0;
+    int out_wo_data_size = out_work_order_data.size();
+
+    for (auto wo_data : in_work_order_data) {
+        // Execute the input data
+        //EchoResultImpl echo_result_impl;
+        result_str = Process(
+            ByteArrayToString(wo_data.decrypted_data));
+
+        // If the out_work_order_data has entry to hold the data
+        if (i < out_wo_data_size) {
+            tcf::WorkOrderData& out_wo_data = out_work_order_data.at(i);
+            out_wo_data.decrypted_data =
+                ByteArray(result_str.begin(), result_str.end());
+        } else {
+            // Create a new entry
+            out_work_order_data.emplace_back(
+                wo_data.index, ByteArray(result_str.begin(), result_str.end()));
+            }
+
+        i++;
+    }
+}
+

--- a/examples/apps/echo/workload/echo.h
+++ b/examples/apps/echo/workload/echo.h
@@ -16,8 +16,23 @@
 #pragma once
 
 #include <string>
+#include "work_order_data.h"
+#include "work_order_processor_interface.h"
 
-class EchoResultImpl {
+class EchoResult: public tcf::WorkOrderProcessorInterface {
+private:
+    std::string Process(std::string str_in);
+
 public:
-        std::string Process(std::string str_in);
+    EchoResult(void);
+    virtual ~EchoResult(void);
+
+    void ProcessWorkOrder(
+                std::string workload_id,
+                const ByteArray& participant_address,
+                const ByteArray& enclave_id,
+                const ByteArray& work_order_id,
+                const std::vector<tcf::WorkOrderData>& in_work_order_data,
+                std::vector<tcf::WorkOrderData>& out_work_order_data);
 };
+

--- a/examples/apps/heart_disease_eval/workload/heart_disease_evaluation.h
+++ b/examples/apps/heart_disease_eval/workload/heart_disease_evaluation.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "work_order_data.h"
+#include "work_order_processor_interface.h"
 
 double model_A(double max, double opt, double data);
 
@@ -47,4 +49,36 @@ double score_thaldur(int durationMin);
 
 double score_num(int num);
 
-std::string executeWorkOrder(std::string decrypted_user_input_str);
+//std::string executeWorkOrder(std::string decrypted_user_input_str);
+
+class HeartDiseaseEval: public tcf::WorkOrderProcessorInterface {
+private:
+        std::string executeWorkOrder(std::string decrypted_user_input_str);
+        double model_A(double max, double opt, double data);
+        double model_B(double max, double opt, double data);
+        double score_age(double data);
+        double score_sex(int sex);
+        double score_cp(int cp_type);
+        double score_trestbps(double data);
+        double score_chol(double data);
+        double score_fbs(double data);
+        double score_restecg(int type);
+        double score_thalach(double data);
+        double score_exang_oldpeak(int type);
+        double score_slop(int type);
+        double score_ca(int number);
+        double score_thaldur(int durationMin);
+        double score_num(int num);
+
+public:
+        HeartDiseaseEval(void);
+        virtual ~HeartDiseaseEval(void);
+
+        void ProcessWorkOrder(
+                std::string workload_id,
+                const ByteArray& participant_address,
+                const ByteArray& enclave_id,
+                const ByteArray& work_order_id,
+                const std::vector<tcf::WorkOrderData>& in_work_order_data,
+                std::vector<tcf::WorkOrderData>& out_work_order_data);
+};


### PR DESCRIPTION
- Move EchoResult and HeartDiseaseEvalFactory classes from
  dispatcher to respective workloads. This decouples dispacther code from workloads

Signed-off-by: manju956 <manjunath.a.c@intel.com>