### PR TITLE
Fix worker registry crash

### DIFF
--- a/examples/common/python/connectors/direct/tcs_listener/tcs_worker_registry_handler.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_worker_registry_handler.py
@@ -312,7 +312,6 @@ class TCSWorkerRegistryHandler:
             json_dict = json.loads(value)
             input_value = json.loads(input_json_str)
             worker_details = input_value ["params"]["details"]
-            worker_details = json.loads(worker_details)
             for item in worker_details:
                 json_dict["details"][item] = worker_details[item]
             


### PR DESCRIPTION
When worker update flow is called, worker registry handler crashes.
Removed wrong JSON deserialization

Signed-off-by: manju956 <manjunath.a.c@intel.com>