### PR TITLE
fix contract wrapper and readme

### DIFF
--- a/examples/common/python/connectors/TestingContracts.md
+++ b/examples/common/python/connectors/TestingContracts.md
@@ -1,27 +1,60 @@
-Requirements:
+# Test Process
+
 1. Installing Python 3.6.8
+
+    ```bash
     wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz
     tar -xvf Python-3.6.8.tgz
     cd Python-3.6.8
     ./configure
-    make 
+    make
     sudo make install
-    make sure 
+    make sure
+    ```
+
 2. Install web3.py an Ethereum python client interact with Ethereum network(About web3.py - https://web3py.readthedocs.io/en/stable/quickstart.html)
+
+    ```bash
     sudo pip install web3
+    ```
+
 3. Install solc to compile solidity contract from python
+
+    ```bash
     python3 -m solc.install v0.4.25
+    ```
+
 4. Set the solidity compiler binary path, so that it is accessible in python program
+
+    ```bash
     export SOLC_BINARY=~/.py-solc/solc-v0.4.25/bin/solc
+    ```
+
 5. Running smart contract using ropsten network account
 Install meta mask chrome plugin and create account in ropsten network.
-After creating account make sure to add fake ether to account using https://faucet.metamask.io/
-https://blog.bankex.org/how-to-buy-ethereum-using-metamask-ccea0703daec
+After creating account make sure to add fake ether to account using
 
-Test DirectRegistry and WorkerRegistry contract using ropsten account
-export WALLET_PRIVATE_KEY=<private_key>
+    - https://faucet.metamask.io/
+    - https://blog.bankex.org/how-to-buy-ethereum-using-metamask-ccea0703daec
 
-cd connectors/ethereum/unit_tests
-python3 test_ethereum_worker_registry_impl.py
-python3 test_ethereum_worker_registry_list_impl.py
+    Expose your private key:
 
+    ```bash
+    export WALLET_PRIVATE_KEY=<private_key>
+    ```
+
+    Deploy contracts:
+
+    ```bash
+    python3 connectors/ethereum/eth_cli.py
+    ```
+
+    Fill in your own ropsten address `eth_account` and contract addresses `direct_registry_contract_address`,`worker_registry_contract_address` in `tcf_connector.toml`
+
+    Then, test DirectRegistry and WorkerRegistry contract:
+
+    ```bash
+    cd connectors/ethereum/unit_tests
+    python3 test_ethereum_worker_registry_impl.py
+    python3 test_ethereum_worker_registry_list_impl.py
+    ```

--- a/examples/common/python/connectors/ethereum/eth_cli.py
+++ b/examples/common/python/connectors/ethereum/eth_cli.py
@@ -59,7 +59,7 @@ class eth_cli:
 def main():
     tcf_home = os.environ.get("TCF_HOME", "../../")
     eth = eth_cli(tcf_home + "/examples/common/python/connectors/" + "tcf_connector.toml")
-    eth.deploy_contracts();
+    eth.deploy_contracts()
 
 if __name__ == '__main__':
     main()

--- a/examples/common/python/connectors/ethereum/unit_tests/test_ethereum_worker_registry_impl.py
+++ b/examples/common/python/connectors/ethereum/unit_tests/test_ethereum_worker_registry_impl.py
@@ -55,6 +55,7 @@ orgId: %s\n applicationIds %s\n details %s",
             hex_to_utf(self.__org_id), pretty_ids(self.__application_ids), self.__details)
         result = self.__eth_conn.worker_register(self.__worker_id, self.__worker_type, 
             self.__org_id, self.__application_ids, self.__details)
+        self.assertIsNotNone(result["txn_receipt"], "transaction execution failed")
         logging.info("worker_register status \n{'status': %s', \n'txn_receipt': %s}", 
             result["status"], 
             json.dumps(json.loads(Web3.toJSON(result["txn_receipt"])), indent=4))


### PR DESCRIPTION
I ran the ethereum worker registry contract unit tests and found some problems:
- current codes do not comply with the deployed contracts, which causes the failure of transactions. Users may need to deploy brand new contract themself, 
- there is a bug in the `ethereum_wrapper.py`, namely representing tx hash without `.hex()` transformation.

I fixed the mentioned bugs and also embellished the readme file.
