### PR TITLE
add boot config param for lmdb

### DIFF
--- a/config/tcs_config.toml
+++ b/config/tcs_config.toml
@@ -14,6 +14,7 @@
 
 [KvStorage]
 StoragePath = "config/Kv_Shared_tmp"
+StorageSize = "1 TB"
 # the remote version is of higher priority if enabled
 #remote_url = "http://localhost:9090"
 

--- a/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
@@ -70,8 +70,9 @@ class TCSListener(resource.Resource):
 
         if config["KvStorage"].get("remote_url") is None:
             storage_path = TCFHOME + '/' + config['KvStorage']['StoragePath']
+            storage_size = config['KvStorage']['StorageSize']
             self.kv_helper = KvStorage()
-            if not self.kv_helper.open(storage_path):
+            if not self.kv_helper.open(storage_path, storage_size):
                 logger.error("Failed to open KV Storage DB")
                 sys.exit(-1)
             logger.info("employ the local LMDB")

--- a/examples/common/python/shared_kv/remote_lmdb/lmdb_request_handler.py
+++ b/examples/common/python/shared_kv/remote_lmdb/lmdb_request_handler.py
@@ -49,7 +49,8 @@ class LMDBRequestHandler(resource.Resource):
         self.kv_helper = KvStorage()
 
         storage_path = TCFHOME + '/' + config['KvStorage']['StoragePath']
-        if not self.kv_helper.open(storage_path):
+        storage_size = config['KvStorage']['StorageSize']
+        if not self.kv_helper.open(storage_path, storage_size):
             logger.error("Failed to open KV Storage DB")
             sys.exit(-1)
 

--- a/examples/common/python/utility/utility.py
+++ b/examples/common/python/utility/utility.py
@@ -225,3 +225,13 @@ def decrypted_response(input_json_str, encrypted_session_key):
     return input_json_params
 
 #---------------------------------------------------------------------------------------------
+
+def human_read_to_byte(size):
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    size = size.split() # divide '1 GB' into ['1', 'GB']
+    if len(size) !=2 or int(size[0]) <= 0:
+        raise Exception("Invalid size")
+    num, unit = int(size[0]), size[1]
+    idx = size_name.index(unit)
+    factor = 1024 ** idx
+    return num * factor

--- a/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
+++ b/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py
@@ -354,8 +354,9 @@ def start_enclave_manager(config):
     try:
         if config["KvStorage"].get("remote_url") is None:
             storage_path = TCFHOME + '/' + config['KvStorage']['StoragePath']
+            storage_size = config['KvStorage']['StorageSize']
             kv_helper = KvStorage()
-            if not kv_helper.open(storage_path):
+            if not kv_helper.open(storage_path, storage_size):
                 logger.error("Failed to open KV Storage DB")
                 sys.exit(-1)
             logger.info("employ the local LMDB")

--- a/tc/sgx/common/packages/db_store/lmdb_store.cpp
+++ b/tc/sgx/common/packages/db_store/lmdb_store.cpp
@@ -32,12 +32,6 @@
 /* API for this specific LMDB-backed database store */
 #include "lmdb_store.h"
 
-/*
- * This must be a multiple of the page size (4096)
- *
- * Default to an insanely large max size (1 TB)
- */
-#define DEFAULT_DB_STORE_SIZE (1ULL << 40)
 
 /* -----------------------------------------------------------------
  * CLASS: SafeThreadLock
@@ -89,14 +83,14 @@ public:
 };
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-tcf_err_t tcf::lmdb_store::db_store_init(const std::string& db_path) {
+tcf_err_t tcf::lmdb_store::db_store_init(const std::string& db_path, const size_t map_size) {
     int ret;
 
     ret = mdb_env_create(&lmdb_store_env);
     tcf::error::ThrowIf<tcf::error::SystemError>(ret != 0, "Failed to create LMDB environment");
     ret=mdb_env_set_maxdbs(lmdb_store_env, MAX_DBS);
     tcf::error::ThrowIf<tcf::error::SystemError>(ret != 0, "Failed to set maximum database");
-    ret = mdb_env_set_mapsize(lmdb_store_env, DEFAULT_DB_STORE_SIZE);
+    ret = mdb_env_set_mapsize(lmdb_store_env, map_size);
     tcf::error::ThrowIf<tcf::error::SystemError>(ret != 0, "Failed to set LMDB default size");
 
     /*

--- a/tc/sgx/common/packages/db_store/lmdb_store.h
+++ b/tc/sgx/common/packages/db_store/lmdb_store.h
@@ -28,11 +28,14 @@ namespace tcf {
          *   The path to the LMDB (lightning memory mapped database) which provides
          *   the back-end to this database store implementation
          *
+         * @param map_size
+         *   The maximum size of the database
+         *
          * @return
          *  Success (return TCF_SUCCESS) - database store ready to use
          *  Failure (return nonzero) - database store is unusable
          */
-        tcf_err_t db_store_init(const std::string& db_path);
+        tcf_err_t db_store_init(const std::string& db_path, const size_t map_size);
 
         /**
          * Close the database store and flush the data to disk

--- a/tc/sgx/trusted_worker_manager/enclave_wrapper/db_store.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave_wrapper/db_store.cpp
@@ -28,8 +28,8 @@
 
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-void db_store_init(const std::string& db_path) {
-    tcf_err_t presult = tcf::lmdb_store::db_store_init(db_path);
+void db_store_init(const std::string& db_path, const size_t map_size) {
+    tcf_err_t presult = tcf::lmdb_store::db_store_init(db_path, map_size);
     ThrowTCFError(presult);
 }
 

--- a/tc/sgx/trusted_worker_manager/enclave_wrapper/db_store.h
+++ b/tc/sgx/trusted_worker_manager/enclave_wrapper/db_store.h
@@ -20,13 +20,13 @@
  * Initialize the database store - must be called before performing gets/puts
  *
  * @param db_path       path to the persistent database store database
+ * @param map_size      the maximum size of the database
  */
-void db_store_init(const std::string& db_path);
+void db_store_init(const std::string& db_path, const size_t map_size);
 
 /**
  * Close the database store - must be called when exiting
  *
- * @param db_path       path to the persistent database store database
  */
 void db_store_close();
 


### PR DESCRIPTION
this pr fixed issue #19 
add a new human readable storage size to boot lmdb. Its default value is 1 TB, but allows users to change the value in the config file.

Signed-off-by: mengyang02 <mengyang02@baidu.com>