### PR TITLE
ignore cache files by python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ tc/sgx/trusted_worker_manager/enclave/deps/
 tc/sgx/trusted_worker_manager/enclave_wrapper/enclave_u.c
 tc/sgx/trusted_worker_manager/enclave_wrapper/enclave_u.h
 tools/build/_dev/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/


### PR DESCRIPTION
address the missing ignored for `examples/common/python/shared_kv/remote_lmdb/__pycache__` and anything like that