### PR TITLE
Fix Problems Running Heart Evaluation GUI Demo

### DIFF
--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -26,9 +26,11 @@ services:
         - https_proxy
         - no_proxy
     environment:
-        - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD}
+        - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD:-}
+        - DISPLAY=${DISPLAY:-}
     volumes:
       - ./:/project/TrustedComputeFramework
+      - /tmp/.X11-unix:/tmp/.X11-unix
     devices:
       - "/dev/isgx:/dev/isgx"
     working_dir: "/project/TrustedComputeFramework/tools/build"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,8 @@ services:
         - https_proxy
         - no_proxy
     environment:
-        - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD}
+        - TCF_DEBUG_BUILD=${TCF_DEBUG_BUILD:-}
+        - DISPLAY=${DISPLAY:-}
     volumes:
       - ./:/project/TrustedComputeFramework
       - /tmp/.X11-unix:/tmp/.X11-unix

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -101,6 +101,7 @@ RUN wget https://www.openssl.org/source/openssl-1.1.1b.tar.gz \
  && rm -rf openssl-1.1.1b
 # Note: we do _not_ delete openssl-1.1.1b.tar.gz as we re-use it below ..
 
+# py-solc 3.2.0 requires an older version of the solc compiler, 0.4.25
 RUN mkdir -p $HOME/.py-solc/solc-v0.4.25/bin \
   && curl -LsS https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux -o /root/.py-solc/solc-v0.4.25/bin/solc \
   && chmod 0755 /root/.py-solc/solc-v0.4.25/bin/solc

--- a/examples/apps/heart_disease_eval/client/heart_gui.py
+++ b/examples/apps/heart_disease_eval/client/heart_gui.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 # Copyright 2019 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* docker/Dockerfile.tcf-dev: mention py-solc requires older solc compiler 0.4.25
* docker-compose-sgx.yaml: add missing /tmp/.X11-unix volume for X Windows
* docker-compose*.yaml: add missing DISPLAY environment variable
* docker-compose*.yaml: set TCF_DEBUG_BUILD default to empty string
* examples/.../heart_gui.py: make script executible

Signed-off-by: danintel <daniel.anderson@intel.com>