### PR TITLE
Fix Generic Client and Add Generic Client Documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -136,7 +136,7 @@ See [examples/apps/heart_disease_eval](examples/apps/heart_disease_eval]
 
 ## <a name="troubleshooting"></a>Troubleshooting
 - If you see the message
-  `ModuleNotFoundError: No module named 'service_client'`, you did not run
+  `ModuleNotFoundError: No module named '...'`, you did not run
   `source _dev/bin/activate`
 
 ## <a name="troubleshootingstandalone"></a>Troubleshooting: Standalone build

--- a/docs/workload-tutorial/README.md
+++ b/docs/workload-tutorial/README.md
@@ -6,7 +6,7 @@ a new directory, `hello_world/workload/`.
 Then we show how to modify the files to create a workload application.
 
 The example we create will be a workload application that takes a name as
-input and echos back "Hello, *name*".
+input and echos back "Hello *name*".
 
 Under directory `hello_world/` are the desired results of modifying the
 template files, `hello_world/stage_1` and, with further modifications,
@@ -35,7 +35,6 @@ The directory structure for this tutorial is as follows:
     * [logic.cpp](hello_world/stage_1/logic.cpp) Modified with worker code added
     * [plug-in.h](hello_world/stage_1/plug-in.h)
     * [plug-in.cpp](hello_world/stage_1/plug-in.cpp) Modified to call worker
-  * [workload/](hello_world/workload/) New directory you create for this tutorial
 
 ## Prerequisites
 
@@ -55,7 +54,8 @@ Before beginning this tutorial, review the following items:
     ` REGISTER_WORKLOAD_PROCESSOR()`
     (see file [templates/plug-in.cpp](templates/plug-in.cpp))
 
-* Review the universal command line client at **[TBD]**
+* Review the generic command line client at
+  [$TCF_HOME/examples/apps/generic_client/](../../examples/apps/generic_client/)
   * This component is optional, but it can be useful because it allows early
     testing of the workload without first creating a custom requester
     application
@@ -64,8 +64,8 @@ Before beginning this tutorial, review the following items:
     If other data types are needed (numbers, binaries), then create
     a custom test application
     (potentially by modifying this application)
-  * Workload ID and input parameters sent by the client must match the
-    workload requirements for this worker (HelloWorld)
+  * The Workload ID (`hello-world`) and input parameters (a name string)
+    sent by the client must match the workload requirements for this worker
 
 As a best practice, this tutorial separates the actual workload-specific logic
 from the the TCF plumbing required to link the workload to the TCF framework
@@ -108,7 +108,7 @@ will be created next in [Phase 2](#phase2).
   add this line to the end of
   [$TCF_HOME/examples/apps/CMakeLists.txt](../../examples/apps/CMakeLists.txt) :
 
-  ```bash
+  ```
   ADD_SUBDIRECTORY(hello_world/workload)
   ```
 
@@ -130,14 +130,28 @@ will be created next in [Phase 2](#phase2).
 * Rebuild the framework (see [$TCF_HOME/BUILD.md](../../BUILD.md)).
   It should include the new workload (with the hard-coded placeholder string)
 
-* Load the framework and use the universal command line utility to test the
-  newly-added workload
+* Load the framework and use the generic command line utility to test the
+  newly-added workload:
+  ```bash
+  ../generic_client/generic_client.py --uri "http://localhost:1947" \
+      --workload_id "hello-world" --in_data "Dan"
+  ```
 
 * The Hello World worker should return the string `Error: under construction`
-  as the result (hard-coded placeholder string in `plug-in.cpp`)
- 
-To see what the updated files should look like, refer to the files in directory
-[hello_world/stage_1/](docs/workload-tutorial/hello_world/stage_1/).
+  as the result (hard-coded placeholder string in `plug-in.cpp`):
+  ```
+  [17:35:06 INFO    utility.utility]
+  Decryption result at client - Error: under construction
+  [17:35:06 INFO    __main__]
+  Decrypted response:
+   [{'index': 0, 'dataHash':
+     '60AEBCFC13614F392352DC5683486C05F5519C927FA35DC254204CA0E5045348',
+     'data': 'Error: under construction', 'encryptedDataEncryptionKey': '',
+     'iv': ''}]
+  ```
+
+To see what the updated source files should look like, refer to the files in
+directory [hello_world/stage_1/](docs/workload-tutorial/hello_world/stage_1/).
 
 
 ### <a name="phase2"></a>Phase 2: Worker-specific Code
@@ -183,13 +197,25 @@ In this example we name the worker-specific function `ProcessHelloWorld()`.
 * Rebuild the framework (see [$TCF_HOME/BUILD.md](../../BUILD.md)).
   It should now include the new workload
 
-* Load the framework and use the universal command line utility to test the
-  newly-added workload
+* Load the framework and use the generic command line utility to test the
+  newly-added workload:
+  ```bash
+  ../generic_client/generic_client.py --uri "http://localhost:1947" \
+      --workload_id "hello-world" --in_data "Dan"
+  ```
 
 * The Hello World worker should return a string
-  `Hello, name` where `name` is the string sent in the first
+  `Hello name` where `name` is the string sent in the first
   input parameter
+  ```
+  [17:47:48 INFO    utility.utility] Decryption result at client - Hello Dan
+  [17:47:48 INFO    __main__]
+  Decrypted response:
+  [{'index': 0, 'dataHash':
+    '02D0D64CA3F5BC43B29304DA25AE9D240A48DE0374C3296A564CE55FB63E0B8C',
+    'data': 'Hello Dan', 'encryptedDataEncryptionKey': '', 'iv': ''}]
+  ```
 
-To see what the updated files should look like, refer to the files in directory
-[hello_world/stage_2/](docs/workload-tutorial/hello_world/stage_2/).
+To see what the updated source files should look like, refer to the files in
+directory [hello_world/stage_2/](docs/workload-tutorial/hello_world/stage_2/).
 

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -16,3 +16,6 @@ create and write new applications.
   a person.
   Clients are available in a X Windows GUI and command line versions
 
+- [Generic Workload Client](generic_client)
+  This is a generic client for testing with any worker
+

--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -1,0 +1,66 @@
+# Generic Workload Client
+
+This is a generic command line client intended to work with any
+workload application. The intention is to get up to speed quickly
+in application development by providing a generic client that works
+with any worker.
+
+## Using the Client
+
+The command line client, `generic_client.py` sends a message to the worker.
+For command line options, type `./generic_client.py -h` from this directory.
+
+```
+usage: generic_client.py [-h] [-c CONFIG] [-u URI | -a ADDRESS] [-m MODE]
+                         [-w WORKER_ID] [-l WORKLOAD_ID] [-i IN_DATA]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        The config file containing the Ethereum contract
+                        information
+  -u URI, --uri URI     Direct API listener endpoint
+  -a ADDRESS, --address ADDRESS
+                        an address (hex string) of the smart contract (e.g.
+                        Worker registry listing)
+  -m MODE, --mode MODE  should be one of listing or registry
+  -w WORKER_ID, --worker_id WORKER_ID
+                        worker id (hex string) to use to submit a work order
+  -l WORKLOAD_ID, --workload_id WORKLOAD_ID
+                        workload id (hex string) for a given worker
+  -i IN_DATA, --in_data IN_DATA
+                        Input data
+```
+
+The `--mode` option is used only with an Ethereum smart contract address.
+Currently only “listing” mode is supported.
+This will fetch the uri from ethereum blockchain, do a worker lookup to fetch
+worker details of first worker in the list, and submit work order.
+
+If `--uri` is passed, `--mode` is not used. It will fetch the worker details
+from the LMDB database and submit work order to the first available worker.
+The TCF Listener uses TCP port 1947, so the URI is usually
+`http://localhost:1947` .
+
+## Examples
+
+### Echo workload using a URI
+```
+./generic_client.py --uri "http://localhost:1947" \
+    --workload_id "echo-result" --in_data "Hello"
+```
+
+### Heart disease eval workload using a URI
+```
+./generic_client.py --uri "http://localhost:1947" \
+    --workload_id "heart-disease-eval" \
+    --in_data "Data: 25 10 1 67  102 125 1 95 5 10 1 11 36 1"
+```
+
+### Echo workload using registry listing smart contract address
+```
+./generic_client.py \
+    --address "0x9Be28B132aeE1b2c5A1C50529a636cEd807842cd" --mode "listing" \
+    --workload_id "echo-result" --in_data "Hello"
+```
+

--- a/examples/common/python/connectors/direct/direct_json_rpc_api_adaptor_factory.py
+++ b/examples/common/python/connectors/direct/direct_json_rpc_api_adaptor_factory.py
@@ -37,12 +37,12 @@ class DirectJsonRpcApiAdaptorFactory(ConnectorAdaptorFactoryInterface):
     4. Work order receipt interact with json rpc listener
     """
     def __init__(self, config_file=None,config=None):
-	"""
-	config_file is config file path as a string
-	config is a dictionary loaded from config_file
-	either one of config_file or config needs to be passed
-	if both are passed config takes precedence
-	"""
+        """
+        "config_file" is config file path as a string.
+        "config" is a dictionary loaded from config_file.
+        Either one of config_file or config needs to be passed.
+        If both are passed config takes precedence.
+        """
         if(config is not None):
             self.__config = config
         else:

--- a/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
+++ b/tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
@@ -243,5 +243,5 @@ ADD_CUSTOM_COMMAND(
 # To add a new workload, uncomment the following lines and change
 # $WORKLOAD_STATIC_NAME$ to the appropriate name (such as hello_world):
 #SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-L,${TCF_TOP_DIR}/examples/apps/build/$WORKLOAD_STATIC_NAME$/workload")
-#TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -l$WORKLOAD_STATIC_NAME$ -Wl,--
+#TARGET_LINK_LIBRARIES(${PROJECT_NAME} -Wl,--whole-archive -l$WORKLOAD_STATIC_NAME$ -Wl,--no-whole-archive)
 


### PR DESCRIPTION
* Fix tab/space indent error in
  connectors/direct/direct_json_rpc_api_adaptor_factory.py
* Fix syntax error in comment for tutorial at
  tc/sgx/trusted_worker_manager/enclave/CMakeLists.txt
* Add generic_client/README.md to document the generic client
* Add generic client instructions to app development tutorial
* Clarify troubleshooting note to BUILD.md

Signed-off-by: danintel <daniel.anderson@intel.com>