### PR TITLE
Remove non-GitHub IDs from CODEOWNERS and MAINTAINERS Files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @acmanjun @daniela1 @tjbarnes @sduraisa @manojgop @kmurthy2 @rsriniv3 @yyyarmos @manju956 @danintel @TomBarnes @srinathduraisamy @manojgop @Karthika @ram-srini @EugeneYYY
+* @manju956 @danintel @TomBarnes @srinathduraisamy @manojgop @Karthika @ram-srini @EugeneYYY

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,11 +1,10 @@
-| Name | Gitlab |
+| Name | GitHub |
 | --- | --- |
-| A C Manjunath | acmanjun |
-| Anderson, Daniel | daniela1 |
-| Barnes, Thomas J | tjbarnes |
-| Duraisamy, Srinath | sduraisa |
+| A C Manjunath | manju956 |
+| Anderson, Daniel | danintel |
+| Barnes, Thomas J | TomBarnes |
+| Duraisamy, Srinath | srinathduraisamy |
 | Gopalakrishnan, Manoj | manojgop |
-| Murthy, Karthika | kmurthy2 |
-| Srinivasamurthy, Ramakrishna | rsriniv3 |
-| Yarmosh, Yevgeniy Y | yyyarmos |
-
+| Murthy, Karthika | Karthika |
+| Srinivasamurthy, Ramakrishna | ram-srini |
+| Yarmosh, Yevgeniy Y | EugeneYYY |


### PR DESCRIPTION
The non-GitHUB IDs are leftover from the previous
source repository host.

Signed-off-by: danintel <daniel.anderson@intel.com>