### PR TITLE
introduce library json-rpc to ease unwrapping requests and wrapping responses in tcs_worker_order_handler

### DIFF
--- a/tools/build/Makefile
+++ b/tools/build/Makefile
@@ -41,6 +41,7 @@ $(PYTHON_DIR) : $(DSTDIR)
 	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade colorlog
 	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade twisted
 	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade protobuf
+	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade json-rpc
 
 $(DSTDIR) :
 	mkdir -p $(DSTDIR)


### PR DESCRIPTION
Manually coding the process of unwrapping requests and wrapping responses in JSON-RPC is error-prone and tedious. So I make use of json-rpc library to simplify this process

Signed-off-by: Sammy <lixiangmin01@baidu.com>