### PR TITLE
Allow Work orders without signature and verifying key

### DIFF
--- a/examples/apps/generic_client/README.md
+++ b/examples/apps/generic_client/README.md
@@ -38,6 +38,8 @@ optional arguments:
                         If present, display JSON output items
   -r, --receipt
                         If present, retrieve and display work order receipt 
+  -rs, --requester_signature
+                        If present, enable requester signature for work order requests
 ```
 
 The `--mode` option is used only with an Ethereum smart contract address.

--- a/examples/apps/heart_disease_eval/client/heart_gui.py
+++ b/examples/apps/heart_disease_eval/client/heart_gui.py
@@ -232,11 +232,15 @@ class resultWindow(tk.Toplevel):
 		)
 		wo_params.add_in_data(message)
 
-		private_key = utility.generate_signing_keys()
 		wo_params.add_encrypted_request_hash()
-		if wo_params.add_requester_signature(private_key) == False:
-			logger.info("Work order request signing failed\n")
-			sys.exit(1)
+
+		if requester_signature:
+			private_key = utility.generate_signing_keys()
+			# Add requester signature and requester verifying_key
+			if wo_params.add_requester_signature(private_key) == False:
+				logger.info("Work order request signing failed")
+				exit(1)
+
 		# Set text for JSON sidebar
 		req_id = 51
 		self.request_json = wo_params.to_string()
@@ -423,6 +427,7 @@ def ParseCommandLine(args) :
 	global verbose
 	global config
 	global off_chain
+	global requester_signature
 
 	parser = argparse.ArgumentParser()
 	use_service = parser.add_mutually_exclusive_group()
@@ -443,6 +448,9 @@ def ParseCommandLine(args) :
 		type=str)
 	parser.add_argument("-v", "--verbose", 
 		help="increase output verbosity", 
+		action="store_true")
+	parser.add_argument("-rs", "--requester_signature",
+		help="Enable requester signature for work order requests",
 		action="store_true")
 
 	options = parser.parse_args(args)
@@ -480,6 +488,8 @@ def ParseCommandLine(args) :
 		service_uri = config["tcf"].get("json_rpc_uri")
 		off_chain = True
 		uri_client = GenericServiceClient(service_uri) 
+
+	requester_signature = options.requester_signature
 
 	service_uri = options.service_uri
 	verbose = options.verbose

--- a/examples/common/python/connectors/direct/work_order_jrpc_impl.py
+++ b/examples/common/python/connectors/direct/work_order_jrpc_impl.py
@@ -49,7 +49,7 @@ class WorkOrderJRPCImpl(WorkOrderInterface):
             "requesterNonce":True,
             "encryptedRequestHash":True,
             "requesterSignature":False,
-            "verifyingKey":True
+            "verifyingKey":False
             }
         self.__data_key_map = {
             "index":True,

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.cpp
@@ -61,20 +61,29 @@ namespace tcf {
             "payloadFormat",
             "invalid request; failed to retrieve payload format");
 
+        /* verifyingKey is optional field. This parameter is not described
+           in spec and the purpose of this parameter is to verify
+           requester signature. Hence don't throw exception
+           if param is not there or empty value.
+        */
         verifying_key = GetJsonStr(
             params_object,
             "verifyingKey",
-            "invalid request; failed to retrieve verifyingKey");
+            nullptr);
 
+        // resultUri is optional field. Hence don't throw exception
+        // if param is not there or empty in the request.
         result_uri = GetJsonStr(
             params_object,
             "resultUri",
-            "invalid request; failed to retrieve result uri");
+            nullptr);
 
+        // notifyUri is optional field. Hence don't throw exception
+        // if param is not there or empty in the request.
         notify_uri = GetJsonStr(
             params_object,
             "notifyUri",
-            "invalid request; failed to retrieve notify uri");
+            nullptr);
 
         work_order_id = GetJsonStr(
             params_object,
@@ -96,15 +105,19 @@ namespace tcf {
             "requesterId",
             "invalid request; failed to retrieve requester id");
 
+        // workerEncryptionKey is optional field. Hence don't throw exception
+        // if param is not there or empty in the request.
         worker_encryption_key = GetJsonStr(
             params_object,
             "workerEncryptionKey",
-            "invalid request; failed to retrieve worker encryption key");
+            nullptr);
 
+        // dataEncryptionAlgorithm is optional field. Hence don't throw exception
+        // if param is not there or empty in the request.
         data_encryption_algorithm = GetJsonStr(
             params_object,
             "dataEncryptionAlgorithm",
-            "invalid request; failed to retrieve encryption algorithm");
+            nullptr);
 
         encrypted_session_key = GetJsonStr(
             params_object,
@@ -126,10 +139,12 @@ namespace tcf {
             "encryptedRequestHash",
             "invalid request; failed to retrieve encrypted request hash");
 
+        // requesterSignature is optional field. Hence don't throw exception
+        // if param is not there or empty in the request.
         requester_signature = GetJsonStr(
             params_object,
             "requesterSignature",
-            "invalid request; failed to retrieve requester signature");
+            nullptr);
 
         if (data_encryption_algorithm.length() > 0) {
             tcf::error::ThrowIf<tcf::error::ValueError>(data_encryption_algorithm != "AES-GCM-256",
@@ -327,7 +342,7 @@ namespace tcf {
         return verify_status;
     }
 
-    int WorkOrderProcessor::VerifySignature() {
+    int WorkOrderProcessor::VerifyRequesterSignature() {
         ByteArray final_hash = ComputeRequestHash();
         ByteArray Signature_byte = base64_decode(requester_signature);
 
@@ -449,9 +464,11 @@ namespace tcf {
         try {
             ParseJsonInput(enclaveData, json_str);
             tcf::error::ThrowIf<tcf::error::ValueError>(VerifyEncryptedRequestHash()!= TCF_SUCCESS,
-                            "Decryption of client request hash failed. Request is tampered.");
-            tcf::error::ThrowIf<tcf::error::ValueError>(VerifySignature()!= true,
-                            "Signature Verification of client request failed. Request is tampered.");
+                "Decryption of client request hash failed. Request is tampered.");
+            if (!requester_signature.empty()) {
+                tcf::error::ThrowIf<tcf::error::ValueError>(VerifyRequesterSignature()!= true,
+                    "Signature verification of client request failed. Request is tampered.");
+            }
             std::vector<tcf::WorkOrderData> wo_data = ExecuteWorkOrder();
             int i = 0;
             int out_data_size = data_items_out.size();

--- a/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
+++ b/tc/sgx/trusted_worker_manager/enclave/work_order_processor.h
@@ -37,7 +37,7 @@ namespace tcf {
                 ByteArray ComputeRequestHash();
                 ByteArray ResponseHashCalculate(std::vector<tcf::WorkOrderData>& wo_data);
                 tcf_err_t VerifyEncryptedRequestHash();
-                int VerifySignature();
+                int VerifyRequesterSignature();
                 void ComputeSignature(EnclaveData& enclaveData, ByteArray& message_hash);
                 void ConcatHash(ByteArray& dst, ByteArray& src);
                 /***Required for work order processing **/


### PR DESCRIPTION
- Since requester signature is not mandatory, work order requests
  without signature and verifying key should be processed.
- Added command line option to enable requester signature.
- Changes to allow empty/no resultUri, notifyUri, workerEncryptionKey and dataEncryptionAlgorithm are added.

Signed-off-by: manju956 <manjunath.a.c@intel.com>