### PR TITLE
Documentation Fixes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -33,8 +33,10 @@ Follow the instructions below to execute a Docker-based build and execution.
 
    **Intel SGX Simulator mode (for hosts without Intel SGX)**:
    1. Run `sudo docker-compose up --build`
-   2. For the subsequent builds on the same workspace, build time can be
-      reduced by executing this command:
+   2. For subsequent runs on the same workspace, if you changed a
+      source or configuration file, run the above command again
+   3. For subsequent runs on the same workspace, if you did not make any
+      changes, startup and build time can be reduced by running:
       `MAKECLEAN=0 sudo -E docker-compose up`
 
    **SGX Hardware mode (for hosts with Intel SGX)**:
@@ -42,10 +44,13 @@ Follow the instructions below to execute a Docker-based build and execution.
       [PREREQUISITES document](PREREQUISITES.md) to install SGX pre-requisites
       and to configure IAS keys.
    2. Run `sudo docker-compose -f docker-compose-sgx.yaml up --build`
-   3. For the subsequent builds on the same workspace, build time can be
-      reduced by executing this command:
+   3. For subsequent runs on the same workspace, if you changed a
+      source or configuration file, run the above command again
+   4. For subsequent runs on the same workspace, if you did not make any
+      changes, startup and build time can be reduced by running:
       `MAKECLEAN=0 sudo -E docker-compose -f docker-compose-sgx.yaml up`
 3. On a successful run, you should see the message `BUILD SUCCESS`
+   followed by a repetitive message `Enclave manager sleeping for 10 secs`
 4. Open a Docker container shell using following command
    `sudo docker exec -it tcf bash`
 5. Activate a Python virtual environment in the Docker shell using following
@@ -68,52 +73,53 @@ components on which TCF depends.
 ## <a name="installtcf"></a>Standalone: Installing TCF Using Scripts
 This section describes how to get started with TCF quickly using provided
 scripts to compile and install TCF.
+The steps below will set up a Python virtual environment to run TCF.
 
-First, make sure environment variables are set as described in the
-[PREREQUISITES document](PREREQUISITES.md).
+1. Make sure environment variables are set as described in the
+   [PREREQUISITES document](PREREQUISITES.md)
 
-The steps below will set up a Python virtual environment to install things
-into.  Download the TCF source repository if you have not already done this:
-```
-git clone https://github.com/hyperledger-labs/trusted-compute-framework
-cd trusted-compute-framework
-```
+2. Download the TCF source repository if you have not already done this:
+   ```
+   git clone https://github.com/hyperledger-labs/trusted-compute-framework
+   cd trusted-compute-framework
+   ```
 
- Set `TCF_HOME` to the top level directory of your
-`trusted-compute-framework` source repository.
-You will need these environment variables set in every shell session
-where you interact with TCF.
-Append this line (with `pwd` expanded) to your login shell script (`~/.bashrc` or similar):
-```
-export TCF_HOME=`pwd`
-echo "export TCF_HOME=$TCF_HOME" >> ~/.bashrc
-```
+3. Set `TCF_HOME` to the top level directory of your
+   `trusted-compute-framework` source repository.
+   You will need these environment variables set in every shell session
+   where you interact with TCF.
+   Append this line (with `pwd` expanded) to your login shell script
+   (`~/.bashrc` or similar):
+   ```
+   export TCF_HOME=`pwd`
+   echo "export TCF_HOME=$TCF_HOME" >> ~/.bashrc
+   ```
 
-Change to the quickstart build directory:
-```
-cd $TCF_HOME/tools/build
-```
+4. Change to the quickstart build directory:
+   ```
+   cd $TCF_HOME/tools/build
+   ```
 
-Check that these variables are set before building the code:
-`SGX_DEBUG`, `SGX_MODE`, `SGX_SSL`.
-If `SGX_MODE` is `HW`, also check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
-Refer to the [PREREQUISITES document](PREREQUISITES.md)
-for more details on the above variables.
+5. Check that these variables are set before building the code:
+   `SGX_DEBUG`, `SGX_MODE`, `SGX_SSL`.
+   If `SGX_MODE` is `HW`, also check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
+   Refer to the [PREREQUISITES document](PREREQUISITES.md)
+   for more details on the above variables
 
-Build the Python virtual environment and install TCF components into it:
-```
-sudo make clean
-make
-```
+6. Build the Python virtual environment and install TCF components into it:
+   ```
+   sudo make clean
+   make
+   ```
 
-Activate the new Python virtual environment for the current shell session.
-You will need to do this in each new shell session (in addition to
-exporting environment variables).
-```
-source _dev/bin/activate
-```
-If the virtual environment for the current shell session is activated,
-you will the see this prompt: `(_dev)`
+7. Activate the new Python virtual environment for the current shell session.
+   You will need to do this in each new shell session (in addition to
+   exporting environment variables).
+   ```
+   source _dev/bin/activate
+   ```
+   If the virtual environment for the current shell session is activated,
+   you will the see this prompt: `(_dev)`
 
 # <a name="testing"></a>Testing
 
@@ -127,12 +133,15 @@ Follow these steps to run the `Demo.py` testcase:
 1. For standalone builds only:
    1. Open a new terminal, Terminal 1
    2. `cd $TCF_HOME/scripts`
-   3.  `source $TCF_HOME/tools/build/_dev/bin/activate`
+   3. Run `source $TCF_HOME/tools/build/_dev/bin/activate` .
+      You should see the `(_dev)` prompt
    4. Run `./tcs_startup.sh`
    5. Wait for the listener to start. You should see the message
-      `TCS Listener started on port 1947`
+      `TCS Listener started on port 1947`,
+      followed by a repetitive message `Enclave manager sleeping for 10 secs`
    6. To run the Demo test case, open a new terminal, Terminal 2
-   7. In Terminal 2, run `source $TCF_HOME/tools/build/_dev/bin/activate`
+   7. In Terminal 2, run `source $TCF_HOME/tools/build/_dev/bin/activate`.
+      You should see the `(_dev)` prompt
 2. For Docker-based builds:
    1. Follow the steps above for
       ["Docker-based Build and Execution"](#dockerbuild)

--- a/docs/workload-tutorial/README.md
+++ b/docs/workload-tutorial/README.md
@@ -1,8 +1,7 @@
 # TCF Worker Application Development Tutorial
 
 This tutorial describes how to build a trusted workload application.
-We begin by copying files under directory (folder) `templates/` to
-a new directory, `hello_world/workload/`.
+We begin by copying template files to a new directory.
 Then we show how to modify the files to create a workload application.
 
 The example we create will be a workload application that takes a name as
@@ -16,7 +15,8 @@ The directory structure for this tutorial is as follows:
 
 * [README.md](README.md) This file
 * [templates/](templates/) Templates to copy to create a workload application
-  * [CMakeLists.txt](templates/CMakeLists.txt) CMake file to build this application
+  * [CMakeLists.txt](templates/CMakeLists.txt) CMake file to build this
+    application
   * [logic.h](templates/logic.h) Header file defining worker-specific code
   * [logic.cpp](templates/logic.cpp) C file for worker-specific code
   * [plug-in.h](templates/plug-in.h) Header file defining generic plug-in code
@@ -24,16 +24,17 @@ The directory structure for this tutorial is as follows:
 * [hello_world/](hello_world/) Example workload application
   * [stage_1/](hello_world/stage_1/) Intermediate results from modifying
     template files
-    * [CMakeLists.txt](hello_world/stage_1/CMakeLists.txt) Modified to build worker
+    * [CMakeLists.txt](hello_world/stage_1/CMakeLists.txt) Modified to build
+      worker
     * [logic.h](hello_world/stage_1/logic.h)
     * [logic.cpp](hello_world/stage_1/logic.cpp)
-    * [plug-in.h](hello_world/stage_1/plug-in.h) Modified to define worker framework
-    * [plug-in.cpp](hello_world/stage_1/plug-in.cpp) Modified to implement worker framework
+    * [plug-in.h](hello_world/stage_1/plug-in.h) Modified to define worker
+      framework
+    * [plug-in.cpp](hello_world/stage_1/plug-in.cpp)
   * [stage_2/](hello_world/stage_2/) Final results from adding worker code
-    * [CMakeLists.txt](hello_world/stage_1/CMakeLists.txt)
-    * [logic.h](hello_world/stage_1/logic.h) Modified with worker definitions added
+    * [logic.h](hello_world/stage_1/logic.h) Modified with worker definitions
+      added
     * [logic.cpp](hello_world/stage_1/logic.cpp) Modified with worker code added
-    * [plug-in.h](hello_world/stage_1/plug-in.h)
     * [plug-in.cpp](hello_world/stage_1/plug-in.cpp) Modified to call worker
 
 ## Prerequisites
@@ -103,7 +104,7 @@ will be created next in [Phase 2](#phase2).
   cp ../../../../docs/workload-tutorial/templates/* .
   ```
 
-* Change placeholders `$NameSpace$` (two locations) in file `plug-in.h` 
+* Change placeholders `$NameSpace$` (two locations) in file `plug-in.h`
   to an appropriate workload class name, `HelloWorld`
 
 * Change placeholder `$WorkloadId$` (one location) in file `plug-in.h` to an
@@ -139,10 +140,10 @@ will be created next in [Phase 2](#phase2).
   and rebuild the framework (see [$TCF_HOME/BUILD.md](../../BUILD.md)).
   It should now include the new workload
 
-* Load the framework and use the generic command line utility to test the
-  newly-added workload:
+* From the `$TCF_HOME` directory, load the framework and use the
+  generic command line utility to test the newly-added workload:
   ```bash
-  examples/apps/generic_client/generic_client.py
+  examples/apps/generic_client/generic_client.py \
       --workload_id "hello-world" --in_data "Jane" "Dan"
   ```
 
@@ -179,7 +180,7 @@ In this example we name the worker-specific function `ProcessHelloWorld()`.
 
 * Add the `ProcessHelloWorld()` function definition to `logic.h`:
   ```cpp
-  extern std::string ProcessHelloWorld(std:string in_str);
+  extern std::string ProcessHelloWorld(std::string in_str);
   ```
 
 * Add the `ProcessHelloWorld()` function implementation to `logic.cpp`
@@ -216,8 +217,8 @@ In this example we name the worker-specific function `ProcessHelloWorld()`.
   }
 
   ```
-  After these changes, the workload will prepend "Hello " to each input data 
-  item and will return each resulting string as a separate output data item. 
+  After these changes, the workload will prepend "Hello " to each input data
+  item and will return each resulting string as a separate output data item.
 
 
 * Change to the top-level TCF source repository directory, `$TCF_HOME`,

--- a/examples/common/python/connectors/TestingContracts.md
+++ b/examples/common/python/connectors/TestingContracts.md
@@ -14,11 +14,11 @@
       (activating a virtual environment).
       Then continue with step 8, below.
 
-2.  (standalone builds only) If needed, update the Ethereum account and
+2.  (Standalone builds only) If needed, update the Ethereum account and
     direct registry contract information in `docker/Dockerfile.tcf-dev` and
     `examples/common/python/connectors/tcf_connector.toml`
 
-3. (standalone builds only) Install Python 3.6.8 if not currently installed.
+3. (Standalone builds only) Install Python 3.6.8 if not currently installed.
    Determine your Python version with `python3 --version` .
    If it is not installed, install it as follows:
 
@@ -32,7 +32,7 @@
     make sure
     ```
 
-4. (standalone builds only) Install solc 0.4.25 to compile Solidity contracts
+4. (Standalone builds only) Install solc 0.4.25 to compile Solidity contracts
    from Python:
     ```bash
     python3 -m solc.install v0.4.25
@@ -43,17 +43,18 @@
     export SOLC_BINARY=~/.py-solc/solc-v0.4.25/bin/solc
     ```
 
-5. (standalone builds only) To run smart contracts using a
+5. (Standalone builds only) To run smart contracts using a
    Ropsten network account, first install the MetaMask Chrome plugin
    to your Chrome web browser and create an account in the Ropsten network
 
-6. (standalone builds only) After creating an account, make sure to add
+6. (Standalone builds only) After creating an account, make sure to add
    fake ether to the account using:
 
    - https://faucet.metamask.io/
    - https://blog.bankex.org/how-to-buy-ethereum-using-metamask-ccea0703daec
 
-7. (standalone builds only) Export your ethereum account private key (Get the private key from metamask client):
+7. (Standalone builds only) Export your ethereum account private key
+   (get the private key from metamask client):
 
    ```bash
    export WALLET_PRIVATE_KEY=<private_key>
@@ -71,24 +72,25 @@
 
 10. Fill in your Ropsten testnet address in `eth_account` in `examples/common/python/connectors/tcf_connector.toml`
 
-11. Deploy solidity contracts to Ropsten network using eth_cli.py
+11. Deploy solidity contracts to Ropsten network using `eth_cli.py`
 
     ```bash
     ./eth_cli.py
     ```
 
-    Above command will display the contract instance address for direct_registry_contract_address and woker_registry_contract_address
+    The above command will display the contract instance address for
+    `direct_registry_contract_address` and `worker_registry_contract_address`
 
 12. Fill in your your contract addresses
       `direct_registry_contract_address` and `worker_registry_contract_address`
       in `examples/common/python/connectors/tcf_connector.toml`
 
 13. Test the DirectRegistry and WorkerRegistry contracts with:
-   ```bash
-   cd $TCF_HOME/examples/common/python/connectors/ethereum/unit_tests
-   python3 test_ethereum_worker_registry_impl.py
-   python3 test_ethereum_worker_registry_list_impl.py
-   ```
+    ```bash
+    cd $TCF_HOME/examples/common/python/connectors/ethereum/unit_tests
+    python3 test_ethereum_worker_registry_impl.py
+    python3 test_ethereum_worker_registry_list_impl.py
+    ```
 
 14. Test echo client with direct mode using Ropsten test network.
     ```bash


### PR DESCRIPTION
These doc fixes were made after a developer reviewed and tested the
documentation.

BUILD.md
* Add repetitive message after build is successful
* Clarify rerunning with and without a rebuild (MAKECLEAN=0)
* Number Standalone Build instructions

docs/workload-tutorial/README.md
* Simplify summary at the beginning
* Specify directory to run the generic client
* Continuation character missing for multi-line generic_client.py command line
* Syntax error in `std::string`

examples/common/python/connectors/TestingContracts.md
* Minor formatting and spelling fixes

Signed-off-by: danintel <daniel.anderson@intel.com>