### PR TITLE
PREREQUISITES.md Corrections and Simplifications

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -122,7 +122,7 @@ sudo chmod +x /usr/local/bin/docker-compose
 
 To verify a correct installation, run `docker-compose version`
 
-For details on Docker installation, see 
+For details on Docker installation, see
 https://docs.docker.com/engine/installation/linux/ubuntu
 and
 https://docs.docker.com/compose/install/#install-compose
@@ -143,7 +143,7 @@ The following instructions download the Intel SGX SDK 2.3 and installs it in
 ```
 sudo mkdir -p /opt/intel
 cd /opt/intel
-wget https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin
+sudo wget https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin
 echo "yes" | sudo bash ./sgx_linux_x64_sdk_2.3.101.46683.bin
 ```
 
@@ -290,29 +290,28 @@ wget 'http://http.us.debian.org/debian/pool/main/o/openssl/libssl-dev_1.1.1d-1_a
 sudo dpkg -i libssl1.1_1.1.1d-1_amd64.deb
 sudo dpkg -i libssl-dev_1.1.1d-1_amd64.deb
 sudo apt-get install -f
-dpkg -l libssl1.1 libssl-dev
 ```
+
+To verify installation, type `dpkg -l libssl1.1 libssl-dev` .
 
 ## Alternate method: OpenSSL Build
 If you are unable to locate a suitable pre-compiled package for your system,
 you can build OpenSSL from source using the following commands. If you
 installed the package directly as described above you do *not* need to do this.
-These steps detail installing OpenSSL to the `install` directory under your
-current working directory.
+These steps detail installing OpenSSL to the `~/openssl/install` directory.
 
 ```
-cd /var/tmp
+mkdir -p ~/openssl/install
+cd ~/openssl
 wget https://www.openssl.org/source/openssl-1.1.1d.tar.gz
 tar -xzf openssl-1.1.1d.tar.gz
 cd openssl-1.1.1d/
-mkdir ../install
 ./Configure --prefix=$PWD/../install
 ./config --prefix=$PWD/../install
-THREADS=8
-make -j$THREADS
+make
 make test
-make install -j$THREADS
-cd ..
+make install
+cd ../..
 ```
 
 If the above succeeds, define/extend the `PKG_CONFIG_PATH` environment variable


### PR DESCRIPTION
* Prepend `sudo` to `wget` of SGX SDK binary
* Remove unneeded `THREADS` variable for OpenSSL build
* Do not install OpenSSL in `/var/tmp`

Signed-off-by: danintel <daniel.anderson@intel.com>
tc/sgx/common/CMakeLists.txt