### PR TITLE
Avoid multiple JSON string conversion in HTTP POST

### DIFF
--- a/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
+++ b/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py
@@ -138,7 +138,7 @@ class TCSListener(resource.Resource):
             if encoding == 'application/json':
 
                 try:
-                    input_json_str = json.loads(data.decode('utf-8'))
+                    input_json_str = data.decode('utf-8')
                     input_json = json.loads(input_json_str)
                     jrpc_id = input_json["id"]
                     response = self._process_request(input_json_str)

--- a/examples/common/python/service_client/generic.py
+++ b/examples/common/python/service_client/generic.py
@@ -36,10 +36,10 @@ class GenericServiceClient(object) :
 
     def _postmsg(self, request) :
         """
-        Post a request JSON listener and return the response.
+        Post a request JSON string and return the response.
         """
 
-        data = json.dumps(request).encode('utf8')
+        data = request.encode('utf8')
         datalen = len(data)
 
         url = self.ServiceURL


### PR DESCRIPTION
Client is sending input as JSON string. So avoid converting the input
string again to JSON string in HTTP POST.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>