### PR TITLE
Installation Script and Documentation Fixes

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -174,11 +174,17 @@ install the Intel SGX driver for both standalone and docker builds.
 You need to install the Intel SGX driver whether you build TCF standalone
 or using Docker.
 
-First install these Intel SGX-required packages:
+First install this package:
 
 ```
-sudo apt-get install -y libsgx-enclave-common libelf-dev
+sudo apt-get install -y libelf-dev
 ````
+
+Download and install libsgx-enclave-common version 2.3.101:
+```
+wget https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/libsgx-enclave-common_2.3.101.46683-1_amd64.deb
+sudo dpkg -i libsgx-enclave-common_2.3.101.46683-1_amd64.deb
+```
 
 ### Remove Old `/dev/sgx` Intel SGX Driver
 If device file `/dev/sgx` is present, remove the old driver:
@@ -204,6 +210,7 @@ After uninstalling, reboot with `sudo shutdown -r 0`
 Install the Intel SGX driver:
 
 ```
+cd /var/tmp
 wget https://download.01.org/intel-sgx/linux-2.6/ubuntu18.04-server/sgx_linux_x64_driver_2.5.0_2605efa.bin
 sudo bash ./sgx_linux_x64_driver_2.5.0_2605efa.bin
 ```
@@ -226,16 +233,13 @@ ias_api_key = '<ias subscription key obtained from portal>'
 ```
 
 In the same file, if you are behind a corporate proxy,
-update the https_proxy line:
+uncomment and update the https_proxy line:
 
-```
-https_proxy = "http://your-proxy:your-port/"
-```
-If you are not behind a corporate proxy (the usual case),
-then comment out the https_proxy line:
 ```
 #https_proxy = "http://your-proxy:your-port/"
 ```
+If you are not behind a corporate proxy (the usual case),
+then leave this line commented out.
 
 **The following steps apply only to standalone builds.**
 

--- a/config/tcs_config.toml
+++ b/config/tcs_config.toml
@@ -25,9 +25,9 @@ StorageSize = "1 TB"
 LogLevel = "INFO"
 LogFile  = "__screen__"
 
-# --------------------------------------------------------------
-# EnclaveManager -- configuration of SGX Enclave EnclaveManager
-# --------------------------------------------------------------
+# -------------------------------------------------------------------
+# EnclaveManager -- configuration of Intel SGX Enclave EnclaveManager
+# -------------------------------------------------------------------
 [EnclaveManager]
 sleep_interval = "10"
 
@@ -35,12 +35,13 @@ sleep_interval = "10"
 listener_port = 1947
 max_work_order_count = 10
 
-# --------------------------------------------------
-# EnclaveModule -- configuration of the SGX Enclave
-# --------------------------------------------------
+# -------------------------------------------------------
+# EnclaveModule -- configuration of the Intel SGX Enclave
+# -------------------------------------------------------
 [EnclaveModule]
-# spid is a 32-digit hex string tied to the enclave implementation
-# Replace dummy SPID with value obtained after subscription to run TCS in SGX HW mode
+# Service Provider ID (SPID) is a 32-digit hex string tied to the
+# enclave implementation. Replace dummy SPID with value obtained after
+# subscription to run TCS in Intel SGX HW mode.
 spid = "DEADBEEF00000000DEADBEEF00000000"
 
 num_of_enclaves = "1"
@@ -48,14 +49,16 @@ num_of_enclaves = "1"
 # ias_url is the URL of the Intel Attestation Service (IAS) server.
 ias_url = "https://api.trustedservices.intel.com/sgx/dev"
 
-# Proxy for https. Change to your corporate proxy or comment out below line for direct Internet connections.
-https_proxy = "http://proxy-iind.intel.com:912/"
+# Proxy for https. Leave commented out for direct Internet connections or
+# uncomment and change to your corporate proxy.
+#https_proxy = "http://your-proxy:your-port/"
 
-# IAS api key is subscription key used for authentication of requests submitted to IAS server.
-# this can be obtained by subscribing in the portal https://api.portal.trustedservices.intel.com.
-ias_api_key = "7eff11484faabcd7b5d62006f4611122"
+# IAS API key is a 32-digit hex string subscription key used for authentication
+# of requests submitted to the IAS server. Obtain the key by subscribing in
+# the portal https://api.portal.trustedservices.intel.com/
+ias_api_key = "112233445566778899aabbccddeeff00"
 
-#enclave library to be used
+# TEE enclave library to use.
 enclave_library = "libtcf-enclave.signed.so"
 enclave_library_path = "tc/sgx/trusted_worker_manager/enclave/build/lib/"
 
@@ -65,7 +68,8 @@ enclave_library_path = "tc/sgx/trusted_worker_manager/enclave/build/lib/"
 [WorkerConfig]
 ProofDataType = "TEE-SGX-IAS"
 
-# Following URIs are used in direct model to submit work orders in synchronous, asynchronous, pull and notification modes
+# The Following URIs are used in direct model to submit work orders in
+# synchronous, asynchronous, pull and notification modes.
 WorkOrderSyncUri = "http://localhost:8080"
 WorkOrderAsyncUri = "http://localhost:8080"
 WorkOrderPullUri = "http://localhost:8080"
@@ -88,10 +92,12 @@ FromAddress = ""
 HashingAlgorithm = "SHA-256"
 # Optional - Comma separated list of signing algorithms. Default is SECP256K1
 SigningAlgorithm = "SECP256K1"
-# Asymmetric encryption algorithm used to encrypt Symmetric data encryption key. Default is RSA-OAEP-3072
+# Asymmetric encryption algorithm used to encrypt Symmetric data encryption key.
+# Default is RSA-OAEP-3072
 KeyEncryptionAlgorithm = "RSA-OAEP-3072"
 # Comma separated list of encryption algorithms. Default is AES-GCM-256
 DataEncryptionAlgorithm = "AES-GCM-256"
-# Supported Work order formats are JSON-RPC, JSON-RPC-JWT and Custom format starting with tilde "~"
+# Supported work order formats are JSON-RPC, JSON-RPC-JWT, and Custom format
+# starting with tilde "~"
 workOrderPayloadFormats = "JSON-RPC"
 

--- a/tools/rebuild.sh
+++ b/tools/rebuild.sh
@@ -15,11 +15,14 @@
 # limitations under the License.
 
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
-SRCDIR="$(realpath ${SCRIPTDIR}/..)"
-TCF_ENCLAVE_CODE_SIGN_PEM=${SCRIPTDIR}/../enclave.pem
+if [[ -z "$TCF_HOME" ]] ; then
+    export TCF_HOME="$(realpath ${SCRIPTDIR}/..)"
+fi
+if [[ -z "$TCF_ENCLAVE_CODE_SIGN_PEM" ]] ; then
+   export TCF_ENCLAVE_CODE_SIGN_PEM="$TCF_HOME/enclave.pem"
+   echo "Setting default TCF_ENCLAVE_CODE_SIGN_PEM=$TCF_ENCLAVE_CODE_SIGN_PEM"
+fi
 
-#TCF_ENCLAVE_CODE_SIGN_PEM is used by other files, hence setting environment
-export TCF_ENCLAVE_CODE_SIGN_PEM=${SCRIPTDIR}/../enclave.pem
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -66,23 +69,30 @@ if [ -z "$SGX_SSL" -a -d "/opt/intel/sgxssl" ] ; then
 fi
 
 : "${TCF_HOME?Missing environment variable TCF_HOME}"
-: "${TCF_ENCLAVE_CODE_SIGN_PEM?Missing environment variable TCF_ENCLAVE_CODE_SIGN_PEM}"
 : "${SGX_SSL?Missing environment variable SGX_SSL}"
 : "${SGX_SDK?Missing environment variable SGX_SDK}"
 : "${PKG_CONFIG_PATH?Missing environment variable PKG_CONFIG_PATH}"
 
-# Set proxy for Intel Architectural Enclave Service Manager
+# Set proxy for Intel Architectural Enclave Service Manager (AESM) and start
 if [[ ${SGX_MODE} &&  "${SGX_MODE}" == "HW" ]]; then
-    # Add proxy settings
-    echo "proxy type = manual" >> /etc/aesmd.conf
-    echo "aesm proxy = $http_proxy" >> /etc/aesmd.conf
+
+    # Add proxy settings, if proxy is present and not set
+    grep -qs "^proxy type" /etc/aesmd.conf
+    if [ $? -ne 0 -a -n "$http_proxy" ] ; then
+       echo "Setting AESMD proxy type"
+       echo "proxy type = manual" >> /etc/aesmd.conf
+    fi
+    grep -qs "^aesm proxy" /etc/aesmd.conf
+    if [ $? -ne 0 -a -n "$http_proxy" ] ; then
+       echo "Setting AESMD proxy"
+       echo "aesm proxy = $http_proxy" >> /etc/aesmd.conf
+    fi
 
     # Starting aesm service
     echo "Starting aesm service"
     /opt/intel/libsgx-enclave-common/aesm/aesm_service &
 else
-    echo "Setting default SGX mode to SIM"
-    # Setting default SGX mode as SIM
+    echo "Setting default SGX mode=SIM"
     export SGX_MODE=SIM
 fi
 
@@ -136,7 +146,7 @@ NUM_CORES=1
 # BUILD
 # -----------------------------------------------------------------
 yell --------------- COMMON SGX WORKLOAD ---------------
-cd $SRCDIR/common/sgx_workload
+cd $TCF_HOME/common/sgx_workload
 
 mkdir -p build
 cd build
@@ -144,7 +154,7 @@ try cmake ..
 try make "-j$NUM_CORES"
 
 yell --------------- EXAMPLE WORKLOADS ---------------
-cd $SRCDIR/examples/apps
+cd $TCF_HOME/examples/apps
 
 mkdir -p build
 cd build
@@ -152,7 +162,7 @@ try cmake ..
 try make "-j$NUM_CORES"
 
 yell --------------- TC SGX COMMON ---------------
-cd $SRCDIR/tc/sgx/common
+cd $TCF_HOME/tc/sgx/common
 
 mkdir -p build
 cd build
@@ -160,7 +170,7 @@ try cmake ..
 try make "-j$NUM_CORES"
 
 yell --------------- ENCLAVE ---------------
-cd $SRCDIR/tc/sgx/trusted_worker_manager/enclave
+cd $TCF_HOME/tc/sgx/trusted_worker_manager/enclave
 
 mkdir -p build
 cd build
@@ -168,11 +178,11 @@ try cmake ..
 try make "-j$NUM_CORES"
 
 yell --------------- EXAMPLES COMMON PYTHON ---------------
-cd $SRCDIR/examples/common/python
+cd $TCF_HOME/examples/common/python
 try make "-j$NUM_CORES"
 try make install
 
 yell --------------- ENCLAVE MANAGER ---------------
-cd $SRCDIR/examples/enclave_manager
+cd $TCF_HOME/examples/enclave_manager
 try make "-j$NUM_CORES"
 try make install


### PR DESCRIPTION
Installation Script Fixes

These installation fixes were made after a developer reviewed and tested the
installation documentation.

`rebuild.sh`
* Rename SRCDIR to TCF_HOME
* Don't set `proxy type` and `aesm proxy` in `aesmd.conf` if there is no proxy

Signed-off-by: danintel <daniel.anderson@intel.com>

Documentation Fixes

These installation fixes were made after a developer reviewed and tested the
installation documentation.

`PREREQUISITES.md`
* Add `cd /var/tmp` before wget to avoid permission errors
* Must wget libsgx-enclave-common
* Update proxy instructions now that proxy is not set by default

`tcs_config.toml`
* Replace Intel proxy by placeholder: `http://your-proxy:your-port/`
* Replace ias_api_key with a dummy key
* Wrap comment lines at 80 characters and reword.

Signed-off-by: danintel <daniel.anderson@intel.com>