### PR TITLE
Add Missing Apache 2 License to Some Shell Scripts

### DIFF
--- a/scripts/enclave_manager.sh
+++ b/scripts/enclave_manager.sh
@@ -1,4 +1,17 @@
-#!/bin/bash
+#! /bin/bash
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 
 enclave_manager="${TCF_HOME}/examples/enclave_manager/tcf_enclave_manager/enclave_manager.py"
 

--- a/scripts/lmdb.sh
+++ b/scripts/lmdb.sh
@@ -1,4 +1,17 @@
-#!/bin/bash
+#! /bin/bash
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 
 lmdb_server="${TCF_HOME}/examples/common/python/shared_kv/remote_lmdb/lmdb_listener.py"
 

--- a/scripts/propose_requests.sh
+++ b/scripts/propose_requests.sh
@@ -1,4 +1,17 @@
-#!/bin/bash
+#! /bin/bash
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 
 source ${TCF_HOME}/tools/build/_dev/bin/activate
 

--- a/scripts/tcs_listener.sh
+++ b/scripts/tcs_listener.sh
@@ -1,4 +1,17 @@
-#!/bin/bash
+#! /bin/bash
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 
 listener="${TCF_HOME}/examples/common/python/connectors/direct/tcs_listener/tcs_listener.py"
 # Read Listener port from config file


### PR DESCRIPTION
* Add Apache 2 License (required by The Linux Foundation)
* Add space in "#! " shbang line when missing

Signed-off-by: danintel <daniel.anderson@intel.com>