### PR TITLE
Avoid hashing twice for signing data.

### DIFF
--- a/tc/sgx/common/crypto/sig_private_key.cpp
+++ b/tc/sgx/common/crypto/sig_private_key.cpp
@@ -206,16 +206,15 @@ std::string pcrypto::sig::PrivateKey::Serialize() const {
 }  // pcrypto::sig::PrivateKey::Serialize
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// Computes SHA256 hash of message.data(), signs with ECDSA privkey and
-// returns ByteArray containing raw binary data
+// Signs hashMessage.data() with ECDSA privkey and returns ByteArray
+// containing raw binary data. It's expected that caller of this function
+// passes hash value of original message to this function for signing.
 // throws RuntimeError
-ByteArray pcrypto::sig::PrivateKey::SignMessage(const ByteArray& message) const {
-    unsigned char hash[SHA256_DIGEST_LENGTH];
-    // Hash
-    SHA256((const unsigned char*)message.data(), message.size(), hash);
-
-    // Then Sign
-    ECDSA_SIG_ptr sig(ECDSA_do_sign((const unsigned char*)hash, SHA256_DIGEST_LENGTH, private_key_),
+ByteArray pcrypto::sig::PrivateKey::SignMessage(
+    const ByteArray& hashMessage) const {
+    // Sign
+    ECDSA_SIG_ptr sig(ECDSA_do_sign((const unsigned char*)hashMessage.data(),
+        hashMessage.size(), private_key_),
         ECDSA_SIG_free);
     if (!sig) {
         std::string msg("Crypto Error (SignMessage): Could not compute ECDSA signature");

--- a/tc/sgx/common/crypto/sig_private_key.h
+++ b/tc/sgx/common/crypto/sig_private_key.h
@@ -52,9 +52,10 @@ namespace crypto {
             PublicKey GetPublicKey() const;
             // throws RuntimeError
             std::string Serialize() const;
-            // Sign message.data() and return ByteArray containing raw binary signature
+            // Sign hashMessage.data() and return ByteArray containing
+            // raw binary signature
             // throws RuntimeError
-            ByteArray SignMessage(const ByteArray& message) const;
+            ByteArray SignMessage(const ByteArray& hashMessage) const;
 
         private:
             EC_KEY* private_key_;

--- a/tc/sgx/common/crypto/sig_public_key.cpp
+++ b/tc/sgx/common/crypto/sig_public_key.cpp
@@ -296,13 +296,13 @@ std::string pcrypto::sig::PublicKey::SerializeXYToHex() const {
 }  // SerializeXYToHex
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// Verifies SHA256 ECDSA signature of message
+// Verifies ECDSA signature of message. It's expected that caller of
+// this function passes hash value of the original message.
 // input signature ByteArray contains raw binary data
 // returns 1 if signature is valid, 0 if signature is invalid and -1 if there is
 // an internal error
 int pcrypto::sig::PublicKey::VerifySignature(
-    const ByteArray& message, const ByteArray& signature) const {
-    unsigned char hash[SHA256_DIGEST_LENGTH];
+    const ByteArray& hashMessage, const ByteArray& signature) const {
     // Decode signature B64 -> DER -> ECDSA_SIG
     const unsigned char* der_SIG = (const unsigned char*)signature.data();
     ECDSA_SIG_ptr sig(
@@ -310,8 +310,8 @@ int pcrypto::sig::PublicKey::VerifySignature(
     if (!sig) {
         return -1;
     }
-    SHA256((const unsigned char*)message.data(), message.size(), hash);
     // Verify
     return ECDSA_do_verify(
-        (const unsigned char*)hash, SHA256_DIGEST_LENGTH, sig.get(), public_key_);
+        (const unsigned char*)hashMessage.data(), hashMessage.size(),
+        sig.get(), public_key_);
 }  // pcrypto::sig::PublicKey::VerifySignature

--- a/tc/sgx/common/crypto/sig_public_key.h
+++ b/tc/sgx/common/crypto/sig_public_key.h
@@ -53,9 +53,11 @@ namespace crypto {
             // Deserialize EC point (X,Y) to hex string
             // throws RuntimeError, ValueError
             void DeserializeXYFromHex(const std::string& hexXY);
-            // Verify signature signature.data() on message.data() and return 1 if signature is
-            // valid, 0 if signature is not valid or -1 if there was an internal error
-            int VerifySignature(const ByteArray& message, const ByteArray& signature) const;
+            // Verify signature signature.data() on hashMessage.data() and
+            // return 1 if signature is valid,
+            // 0 if signature is not valid or -1 if there was an internal error
+            int VerifySignature(const ByteArray& hashMessage,
+                const ByteArray& signature) const;
 
         private:
             EC_KEY* public_key_;


### PR DESCRIPTION
SignMessage() function is hashing the data before signing.
Client is expected to hash the data as mentioned in Trusted computing
spec. So no need to hash the data again before signing.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>