### PR TITLE
Documentation Changes for SGX and Contributions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -95,10 +95,13 @@ The steps below will set up a Python virtual environment to run TCF.
    echo "export TCF_HOME=$TCF_HOME" >> ~/.bashrc
    ```
 
-4. Check that `SGX_MODE` is set before building the code.
-   If `SGX_MODE` is `HW`, also check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
+4. If you are using Intel SGX hardware, check that `SGX_MODE=HW` before
+   building the code.
+   By default `SGX_MODE=SIM` indicating use the Intel SGX simulator.
+
+   If `SGX_MODE=HW`, also check that `TCF_ENCLAVE_CODE_SIGN_PEM` is set.
    Refer to the [PREREQUISITES document](PREREQUISITES.md)
-   for more details on the above variables
+   for more details on these variables
 
 5. Build the Python virtual environment and install TCF components into it:
    ```
@@ -171,6 +174,8 @@ See [examples/apps/heart_disease_eval](examples/apps/heart_disease_eval)
   1. `sudo rm $TCF_HOME/config/Kv*`
   2. `$TCF_HOME/scripts/tcs_startup.sh -t`
   3. You can re-run the test now
+
+- If you get build errors rerunning `make`, try `sudo make clean` first
 
 - If you see the message `No package 'openssl' found`, you do not have
   OpenSSL libraries or the correct version of OpenSSL libraries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,9 @@ git pull requests.  Each commit must include a DCO line in the git commit messag
 This sign-off means you agree the commit satisfies the
 [Developer Certificate of Origin (DCO).](https://developercertificate.org/)
 
+For other ways to contribute, see
+[Get involved: How to Contribute to Hyperledger](https://www.hyperledger.org/blog/2018/07/11/get-involved-how-to-contribute-to-hyperledger)
+and our
+[community links](https://github.com/hyperledger-labs/trusted-compute-framework/tree/master/docs#community).
+
 © Copyright 2019, Intel Corporation.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,9 @@
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
+# Maintainers
+
 | Name | GitHub | [Rocket.Chat](https://chat.hyperledger.org/channel/avalon) |
 | ---- | ------ | --------------------------------------------------------- |
 | A C Manjunath | [manju956](https://github.com/manju956) | @manju.ac |

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -50,10 +50,11 @@ These are used to find the Intel Software Guard Extensions (SGX) Software
 Development Kit (SDK). They are normally set by sourcing the Intel SGX SDK
 activation script (e.g. `source /opt/intel/sgxsdk/environment`)
 
-- `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` also contain the the path to
-  [OpenSSL](#openssl) package config files and libraries, respectively,
-  if you build your own OpenSSL. You need to do this when pre-built OpenSSL
-  version 1.1.1d or later packages are not available for your system
+- If you build your own OpenSSL (not the usual case),
+  `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` also contain the the path to
+  [OpenSSL](#openssl) package config files and libraries, respectively.
+  You need to do this when pre-built OpenSSL version 1.1.1d or later
+  packages are not available for your system
 
 - `SGX_MODE`
 Optional variable used to switch between the Intel SGX simulator and hardware
@@ -132,6 +133,8 @@ https://docs.docker.com/compose/install/#install-compose
 Hyperledger Trusted Compute Framework is intended to be run on
 Intel SGX-enabled platforms. However, it can also be run in "simulator mode"
 on platforms that do not have hardware support for Intel SGX.
+Support for other hardware-based Trusted Execution Environments (TEEs)
+can be added by submitting a Pull Request.
 
 
 ## Intel SGX SDK

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,28 @@
+<!--
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+-->
 # Hyperledger Security Policy
 
 ## Reporting a Security Bug
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
+If you think you have discovered a security issue in any of the Hyperledger
+projects, we'd love to hear from you. We will take all security bugs
+seriously and if confirmed upon investigation we will patch it within a
+reasonable amount of time and release a public security bulletin discussing
+the impact and credit the discoverer.
 
-There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
+There are two ways to report a security bug. The easiest is to email a
+description of the flaw and any related information (e.g. reproduction
+steps, version) to
+[security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
+The other way is to file a confidential security bug in our
+[JIRA bug tracking system](https://jira.hyperledger.org).
+Be sure to set the “Security Level” to “Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs
+is documented further in our
+[Defect Response](https://wiki.hyperledger.org/display/HYP/Defect+Response)
+page on our [wiki](https://wiki.hyperledger.org).
 


### PR DESCRIPTION
`PREREQUISITES.md`
- Clarify that TCF can support other TEEs
- Emphasize some settings are only used if you build your own OpenSSL

`BUILD.md`
- Mention SGX_MODE is optional
- Mention `sudo make clean` on make errors

` CONTRIBUTING.md`
- Add social media links and Hyperledger link

`SECURITY.md`
- Add license
- Wrap lines

`MAINTAINERS.md`
- Add license

Signed-off-by: danintel <daniel.anderson@intel.com>