### PR TITLE
Build refactor

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -100,9 +100,12 @@ The steps below will set up a Python virtual environment to run TCF.
    Refer to the [PREREQUISITES document](PREREQUISITES.md)
    for more details on the above variables
 
-5. Build the Python virtual environment and install TCF components into it:
+5. Create Python virtual environment, Build and Install TCF
+   components into it:
    ```
    cd $TCF_HOME/tools/build
+   # Create virtual environment directory with name _dev
+   python3 -m venv _dev
    sudo make clean
    make
    ```
@@ -154,6 +157,10 @@ Follow these steps to run the `Demo.py` testcase:
 7. If you wish to exit the TCF program, press `y` and `Enter` at Terminal 1
    for standalone builds.
    For Docker-based builds, press `Ctrl-c`
+8. For standalone mode, delete virtual environment
+   ```
+   rm -rf $TCF_HOME/tools/build/_dev/
+   ```
 
 A GUI is also available to run this demo.
 See [examples/apps/heart_disease_eval](examples/apps/heart_disease_eval)

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -90,9 +90,14 @@ distributions will require similar packages.
 sudo apt-get update
 sudo apt-get install -y cmake swig pkg-config python3-dev python3-venv python \
      software-properties-common virtualenv curl xxd git unzip dh-autoreconf \
-     ocaml ocamlbuild liblmdb-dev protobuf-compiler
+     ocaml ocamlbuild liblmdb-dev protobuf-compiler python3-pip python3-toml \
+     python3-requests python3-colorlog python3-twisted
 ```
 
+Also, install following pip packages
+```
+sudo pip3 install --upgrade setuptools json-rpc py-solc web3
+```
 
 # <a name="docker"></a>Docker
 Docker may be used instead of building TCF directly (standalone mode) and

--- a/ci/docker-compose-tests.yaml
+++ b/ci/docker-compose-tests.yaml
@@ -28,8 +28,7 @@ services:
       - ../:/project/TrustedComputeFramework
     working_dir: "/project/TrustedComputeFramework/tools/build"
     entrypoint: "bash -c \"\
-        source _dev/bin/activate \
-        && cd ../../scripts \
+        cd ../../scripts \
         && source tcs_startup.sh -y \
         && sleep 5 \
         && source ../tools/run_tests.sh \""

--- a/docker-compose-sgx.yaml
+++ b/docker-compose-sgx.yaml
@@ -40,7 +40,6 @@ services:
         if [ ${MAKECLEAN:-1} != 0 ]; then echo \\\"Clean build\\\" && make clean; fi \
         && make \
         && echo \\\"BUILD SUCCESS\\\" \
-        && source _dev/bin/activate \
         && cd ../../scripts \
         && source tcs_startup.sh -y \
         && tail -f /dev/null \""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,6 @@ services:
         if [ ${MAKECLEAN:-1} != 0 ]; then echo \\\"Clean build\\\" && make clean; fi \
         && make \
         && echo \\\"BUILD SUCCESS\\\" \
-        && source _dev/bin/activate \
         && cd ../../scripts \
         && source tcs_startup.sh -y \
         && tail -f /dev/null \""

--- a/docker/Dockerfile.tcf-dev
+++ b/docker/Dockerfile.tcf-dev
@@ -49,9 +49,13 @@ RUN apt-get update \
     cmake \
     protobuf-compiler \
     libprotobuf-dev \
-    python \
     python3-dev \
     virtualenv \
+    python3-pip \
+    python3-toml \
+    python3-requests \
+    python3-colorlog \
+    python3-twisted \
     swig \
     software-properties-common \
     curl \
@@ -67,6 +71,13 @@ RUN apt-get update \
  && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+# Install setuptools, py-solc and web3 packages using pip because
+# these are not available in apt repository.
+RUN pip3 install --upgrade setuptools json-rpc py-solc web3
+
+# Make Python3 default
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # SGX common library and SDK are installed in /opt/intel directory.
 # Installation of SGX libsgx-common packages requires /etc/init directory. In docker image this directory doesn't exist.

--- a/examples/common/python/Makefile
+++ b/examples/common/python/Makefile
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | tr -d .}
 MOD_VERSION=${shell ../../../bin/get_version}
 
-EGG_FILE=dist/tcf_examples_common-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg
+# Format of wheel package is <pkg_name>-{python-tag}-{abi-tag}-{platform}
+WHEEL_FILE=dist/tcf_examples_common-${MOD_VERSION}-cp${PY_VERSION}-cp${PY_VERSION}m-linux_x86_64.whl
 SOURCE_DIR=$(shell pwd)
 
 
-all : $(EGG_FILE)
+all : $(WHEEL_FILE)
 
-$(EGG_FILE) : build_ext
+$(WHEEL_FILE) : build_ext
 	@echo Build Distribution
-	python3 setup.py bdist_egg
+	python3 setup.py bdist_wheel
 	
 build_ext :
 	@echo Build build_ext
@@ -34,10 +35,11 @@ build :
 	cd $@ 
 
 install:
-	@echo INSTALLING EGG FILE =================
-	easy_install $(EGG_FILE)
+	@echo INSTALLING WHEEL FILE =================
+	pip3 install $(WHEEL_FILE)
 
 clean:
+	pip3 uninstall --yes $(WHEEL_FILE)
 	rm -rf build deps dist *.egg-info
 	rm -f crypto/crypto.py crypto/crypto_wrap.cpp
 	rm -f verify_report/verify_report.py verify_report/verify_report_wrap.cpp

--- a/examples/enclave_manager/Makefile
+++ b/examples/enclave_manager/Makefile
@@ -15,20 +15,19 @@
 # Set SGX_MODE default (which can be overridden with an environment variable):
 SGX_MODE?=SIM
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/' | tr -d .}
 MOD_VERSION=${shell ../../bin/get_version}
 
-EGG_FILE=dist/tcf_enclave_manager-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg
+WHEEL_FILE=dist/tcf_enclave_manager-${MOD_VERSION}-cp${PY_VERSION}-cp${PY_VERSION}m-linux_x86_64.whl
 SOURCE_DIR=$(shell pwd)
 EDL_PATH=$(SOURCE_DIR)/../../tc/sgx/trusted_worker_manager/enclave
 ENCLAVE_WRAPPER=$(SOURCE_DIR)/../../tc/sgx/trusted_worker_manager/enclave_wrapper
 
+all : $(WHEEL_FILE)
 
-all : $(EGG_FILE)
-
-$(EGG_FILE) : build_ext
+$(WHEEL_FILE) : build_ext
 	@echo Build Distribution
-	python3 setup.py bdist_egg
+	python3 setup.py bdist_wheel
 
 build_ext :
 	$(SGX_SDK)/bin/x64/sgx_edger8r --untrusted $(EDL_PATH)/enclave.edl --search-path $(SGX_SDK)/include --search-path $(SGX_SSL)/include/ --search-path $(EDL_PATH)
@@ -44,10 +43,11 @@ build :
 	mkdir $@
 
 install:
-	@echo INSTALLING EGG FILE =================
-	easy_install $(EGG_FILE)
+	@echo INSTALLING WHEEL FILE =================
+	pip3 install $(WHEEL_FILE)
 
 clean:
+	pip3 uninstall --yes $(WHEEL_FILE)
 	rm -f $(addprefix $(ENCLAVE_WRAPPER), /enclave_u.c /enclave_u.h)
 	rm -f tcf_enclave_manager/tcf_enclave.py tcf_enclave_manager/tcf_enclave_wrap.cpp
 	rm -rf build deps dist *.egg-info

--- a/tools/build/Makefile
+++ b/tools/build/Makefile
@@ -23,31 +23,13 @@ PKGGEN=$(abspath $(SRCDIR)/../rebuild.sh)
 PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
 PYTHON_DIR=$(DSTDIR)/lib/python$(PY_VERSION)/site-packages/
 
-all: environment template enclavekey packages
+all: template enclavekey packages
 
 clean :
-	rm -rf $(DSTDIR); $(abspath $(SRCDIR)/../clean.sh)
-
-environment : $(PYTHON_DIR)
-
-$(PYTHON_DIR) : $(DSTDIR)
-	virtualenv -p python3 --no-download $(DSTDIR)
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade pip
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade setuptools
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade toml
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade py-solc
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade web3
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade requests
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade colorlog
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade twisted
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade protobuf
-	. $(abspath $(DSTDIR)/bin/activate) ; pip install --upgrade json-rpc
-
-$(DSTDIR) :
-	mkdir -p $(DSTDIR)
+	$(abspath $(SRCDIR)/../clean.sh)
 
 packages :
-	. $(abspath $(DSTDIR)/bin/activate) ; $(PKGGEN)
+	$(PKGGEN)
 
 enclavekey :
 	openssl genrsa -3 -out $(SRCDIR)/../../enclave.pem 3072
@@ -55,4 +37,4 @@ enclavekey :
 template :
 	mkdir -p $(DSTDIR)/opt/tcf/logs
 
-.PHONY : environment packages template
+.PHONY : packages template


### PR DESCRIPTION
- Downloading pip packages is moved from Makefile to Docker image
- Removed virtual environment in docker build
- Python egg packaging is replaced to wheel packaging

Signed-off-by: manju956 <manjunath.a.c@intel.com>