### PR TITLE
Container isolation for parallel builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
     environment {
         ISOLATION_ID = sh(returnStdout: true,
                           script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
+        COMPOSE_PROJECT_NAME = sh(returnStdout: true,
+                          script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
     }
 
     stages {


### PR DESCRIPTION
This commit resolves:  
   - termination of running container of a branch/PR by another parallel instance of same branch/PR
   - COMPOSE_PROJECT_NAME is the parameter given by docker to be used to seperate out the containers/services acorss different runs

Signed-off-by: pankajgoyal2 pankaj.goyal@intel.com