### PR TITLE
Resolve container caching issue in Jenkins

### DIFF
--- a/ci/docker-compose-build.yaml
+++ b/ci/docker-compose-build.yaml
@@ -16,7 +16,6 @@ version: '3.5'
 
 services:
   tcf:
-    container_name: tcf
     image: tcf-ci-build:${ISOLATION_ID}
 
     build:

--- a/ci/docker-compose-tests.yaml
+++ b/ci/docker-compose-tests.yaml
@@ -16,7 +16,6 @@ version: '3.5'
 
 services:
   tcf:
-    container_name: tcf
     image: tcf-ci-build:${ISOLATION_ID}
     build:
       context: .


### PR DESCRIPTION
Each Jenkins job creates a container for TCF build and tests.
If container_name is given in compose file, each jenkins job
will create and destroy the container with name "tcf", which is
not a good situation for parallel jenkins jobs. If, container_name
is not given in compose files, containers will automatically be
assigned with a unique name using COMPOSE_PROJECT_NAME variable
from Jenkinsfile. So, removing container_name from compose files.

Signed-off-by: pankajgoyal2 <pankaj.goyal@intel.com>