### PR TITLE
Add Undocumented Step from Replacing Egg Packaging with Wheel Packaging

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -97,7 +97,7 @@ sudo apt-get install -y cmake swig pkg-config python3-dev python3-venv python \
 
 Also, install following pip packages
 ```
-sudo pip3 install --upgrade setuptools json-rpc py-solc web3
+sudo pip3 install --upgrade setuptools json-rpc py-solc web3 wheel
 ```
 
 # <a name="docker"></a>Docker


### PR DESCRIPTION
The following undocumented step is now needed as a result of this fix:

PR #130 Replace egg packaging with wheel packaging
https://github.com/hyperledger-labs/trusted-compute-framework/pull/130

The change did not update the PREREQUISITES.md documentation.

The undocumented change needed is:

`pip3 install wheel`

Signed-off-by: danintel <daniel.anderson@intel.com>